### PR TITLE
Update 'checkout' Github Action module refs to v3.1.0

### DIFF
--- a/.github/workflows/airflow-operator-release-to-pypi.yml
+++ b/.github/workflows/airflow-operator-release-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - run: make airflow-operator
       - uses: ./.github/workflows/python-tests

--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - run: make airflow-operator
       - uses: ./.github/workflows/python-tests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     # The ArmadaProject.Io.Client needs the generated proto files
     - uses: ./.github/workflows/go-setup

--- a/.github/workflows/go-integration-free.yml
+++ b/.github/workflows/go-integration-free.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - run: make build-ci
       - run: make tests-e2e-setup

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - run: make build-ci
       - run: make tests-e2e-setup

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
 
       - name: golangci-lint
@@ -45,7 +45,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
 
       - name: make tests

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           path: master
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           ref: 'gh-pages'
           path: gh-pages

--- a/.github/workflows/python-client-release-to-pypi.yml
+++ b/.github/workflows/python-client-release-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - uses: ./.github/workflows/python-tests
         with:

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - uses: ./.github/workflows/python-tests
         with:
@@ -46,7 +46,7 @@ jobs:
       matrix:
         go: [ '1.18' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: ./.github/workflows/go-setup
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -21,7 +21,7 @@ jobs:
     # TODO(JayF): Determine what nodejs versions we target, and setup matrix-based testing similar to what we do for go
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3
         with:
           node-version: 16.14.2
@@ -34,7 +34,7 @@ jobs:
   ts-unit-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3
         with:
           node-version: 16.14.2


### PR DESCRIPTION
This fixes the warnings from Github Actions about running old versions of NodeJS (< node 16).